### PR TITLE
[SAAS-7345] Extract sourcemaps from build directory and delete after upload

### DIFF
--- a/index.js
+++ b/index.js
@@ -92,8 +92,8 @@ async function deleteReleaseFilesInSentry(sentryVersion) {
  */
 async function uploadSentrySourceMaps(sentryProject, sentryVersion) {
     console.log('Uploading source maps to Sentry...');
-    const globber = await glob.create(path.resolve('sourcemaps/*.js.map'))
-
+    const globber = await glob.create(path.resolve('build/static/js/*.js.map'))
+    
     for await (const file of globber.globGenerator()) {
         console.log('File: ', file);
         const formData = new FormData();
@@ -117,6 +117,8 @@ async function uploadSentrySourceMaps(sentryProject, sentryVersion) {
             throw e
         }
         console.log('Source map uploaded: ', file);
+        await io.rmRF(file)	
+        console.log('Source map removed');
     }
 }
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "devops-github-actions-frontend-deployment",
-  "version": "2.0.0",
+  "version": "3.0.0",
   "main": "index.js",
   "repository": "https://github.com/Talentwunder/devops-github-actions-frontend-deployment.git",
   "author": "Lukas <meusel.lukas@gmail.com>",


### PR DESCRIPTION
As we had to deploy to `app.talentwunder.com` and `talentwunder.io`, the action was previously changed so that the sourcemaps files are taken from a dedicated sourcemaps directory. Those changes were reverted as deployment to two Cloudfront distributions is no longer necessary.

Referenced PR:
https://github.com/Talentwunder/devops-github-actions-frontend-deployment/pull/3